### PR TITLE
change set-context to use-context

### DIFF
--- a/installer/roles/kubernetes/tasks/kubernetes_auth.yml
+++ b/installer/roles/kubernetes/tasks/kubernetes_auth.yml
@@ -1,3 +1,3 @@
 ---
 - name: Set the Kubernetes Context
-  shell: "kubectl config set-context {{ kubernetes_context }}"
+  shell: "kubectl config use-context {{ kubernetes_context }}"


### PR DESCRIPTION
set-context allows setting configuration within a provided context, to change contexts we need "use-context"

$ kubectl config
...
  set-context     Sets a context entry in kubeconfig
  use-context     Sets the current-context in a kubeconfig file

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "related #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - API
 - UI
 - Installer

##### AWX VERSION
<!--- Paste verbatim output from `make VERSION` between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
